### PR TITLE
chore: use def for base class

### DIFF
--- a/docker-controller-scala-core/src/main/scala/com/github/j5ik2o/dockerController/DockerControllerHelper.scala
+++ b/docker-controller-scala-core/src/main/scala/com/github/j5ik2o/dockerController/DockerControllerHelper.scala
@@ -26,9 +26,9 @@ trait DockerControllerHelper {
 
   protected val dockerClient: DockerClient = DockerClientImpl.getInstance(dockerClientConfig, dockerHttpClient)
 
-  protected val dockerControllers: Vector[DockerController]
+  protected def dockerControllers: Vector[DockerController]
 
-  protected val waitPredicatesSettings: Map[DockerController, WaitPredicateSetting]
+  protected def waitPredicatesSettings: Map[DockerController, WaitPredicateSetting]
 
   protected def createDockerContainer(
       dockerController: DockerController,


### PR DESCRIPTION
It is more convenient to use def in the base classes, as the implementation can be stacked with case patterns.

```scala
// This is invalid
trait Base {
   val controller: Seq[Int]
}
trait A extends Base {
  override val controller: Seq[Int] = Seq(1)
}
object A extends A
trait B extends A {
  override val controller: Seq[Int] = super.controller :+ 2 // Compile Error
}
trait C extends A {
  override val controller: Seq[Int] = super.controller :+ 3 // Compile Error
}
trait D extends B with C
object D extends D 
trait E extends C with B
object E extends E
```

```scala
// valid code
trait Base {
   def controller: Seq[Int]
}
trait A extends Base {
  override def controller: Seq[Int] = Seq(1)
}
object A extends A
trait B extends A {
  override def controller: Seq[Int] = super.controller :+ 2 // It's OK
}
trait C extends A {
  override def controller: Seq[Int] = super.controller :+ 3 // It's OK
}
trait D extends B with C
object D extends D // D.controller = Seq(1,2,3)
trait E extends C with B
object E extends E // E.controller = Seq(1,3,2)

```
