### PR TITLE
chore(renovate): restrict Java version to 17 in mise configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
       "managers": ["sbt"],
       "packageNames": ["sbt-ci-release"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["java"],
+      "allowedVersions": "17"
     }
   ],
   "prHourlyLimit": 0,


### PR DESCRIPTION
## Summary
- Add Renovate configuration to restrict Java version to 17
- Prevent automatic updates to Java 21 or higher versions
- Ensure project compatibility with Java 17 LTS

## Motivation
- The project is currently standardized on Java 17 LTS
- Automatic updates to Java 21 could cause compatibility issues
- This configuration ensures Renovate respects our Java version requirement

## Changes
- Added package rule in renovate.json to restrict mise Java updates to version 17 only

## Related
- Closes #1747 (Java 21 update PR that we don't want to accept)