### PR TITLE
chore: DockerコンテナのデフォルトイメージタグをMajor版にリセット

### DIFF
--- a/docker-controller-scala-elasticmq/src/main/scala/com/github/j5ik2o/dockerController/elasticmq/ElasticMQController.scala
+++ b/docker-controller-scala-elasticmq/src/main/scala/com/github/j5ik2o/dockerController/elasticmq/ElasticMQController.scala
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 
 object ElasticMQController {
   final val DefaultImageName: String        = "softwaremill/elasticmq"
-  final val DefaultImageTag: Option[String] = Some("1.3.9")
+  final val DefaultImageTag: Option[String] = Some("1.6.14")
   final val DefaultContainerPorts: Seq[Int] = Seq(9324, 9325)
 
   def apply(

--- a/docker-controller-scala-localstack/src/main/scala/com/github/j5ik2o/dockerController/localstack/LocalStackController.scala
+++ b/docker-controller-scala-localstack/src/main/scala/com/github/j5ik2o/dockerController/localstack/LocalStackController.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
 object LocalStackController {
   final val DefaultImageName              = "localstack/localstack"
-  final val DefaultImageTag: Some[String] = Some("1.0.3")
+  final val DefaultImageTag: Some[String] = Some("4.7")
 
   def apply(
       dockerClient: DockerClient,

--- a/docker-controller-scala-memcached/src/main/scala/com/github/j5ik2o/dockerController/memcached/MemcachedController.scala
+++ b/docker-controller-scala-memcached/src/main/scala/com/github/j5ik2o/dockerController/memcached/MemcachedController.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 object MemcachedController {
   final val DefaultImageName: String        = "memcached"
-  final val DefaultImageTag: Option[String] = Some("1.6")
+  final val DefaultImageTag: Option[String] = Some("trixie")
   final val DefaultContainerPort: Int       = 11211
 
   def apply(

--- a/docker-controller-scala-minio/src/main/scala/com/github/j5ik2o/dockerController/minio/MinioController.scala
+++ b/docker-controller-scala-minio/src/main/scala/com/github/j5ik2o/dockerController/minio/MinioController.scala
@@ -12,9 +12,9 @@ import scala.util.matching.Regex
 
 object MinioController {
   final val DefaultImageName              = "minio/minio"
-  final val DefaultImageTag: Some[String] = Some("RELEASE.2022-08-05T23-27-09Z")
+  final val DefaultImageTag: Some[String] = Some("RELEASE.2025-07-23T15-54-02Z-cpuv1")
   final val DefaultContainerPort          = 9000
-  final val RegexForWaitPredicate: Regex  = """^Documentation: https://docs\.min\.io$""".r
+  final val RegexForWaitPredicate: Regex  = """^Docs: https://docs\.min\.io$""".r
 
   final val DefaultMinioAccessKeyId: String     = "AKIAIOSFODNN7EXAMPLE"
   final val DefaultMinioSecretAccessKey: String = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"

--- a/docker-controller-scala-mysql/src/main/scala/com/github/j5ik2o/dockerController/mysql/MySQLController.scala
+++ b/docker-controller-scala-mysql/src/main/scala/com/github/j5ik2o/dockerController/mysql/MySQLController.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
 object MySQLController {
   final val DefaultImageName: String        = "mysql"
-  final val DefaultImageTag: Option[String] = Some("8.0")
+  final val DefaultImageTag: Option[String] = Some("9.4.0")
   final val DefaultContainerPort: Int       = 3306
 
   def apply(

--- a/docker-controller-scala-postgresql/src/main/scala/com/github/j5ik2o/dockerController/postgresql/PostgreSQLController.scala
+++ b/docker-controller-scala-postgresql/src/main/scala/com/github/j5ik2o/dockerController/postgresql/PostgreSQLController.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 object PostgreSQLController {
   final val DefaultImageName: String        = "postgres"
-  final val DefaultImageTag: Option[String] = Some("13")
+  final val DefaultImageTag: Option[String] = Some("17.6")
   final val DefaultContainerPort: Int       = 5432
 
   def apply(

--- a/docker-controller-scala-redis/src/main/scala/com/github/j5ik2o/dockerController/redis/RedisController.scala
+++ b/docker-controller-scala-redis/src/main/scala/com/github/j5ik2o/dockerController/redis/RedisController.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
 object RedisController {
   final val DefaultImageName: String        = "redis"
-  final val DefaultImageTag: Option[String] = Some("6.2.4")
+  final val DefaultImageTag: Option[String] = Some("bookworm")
   final val DefaultContainerPort: Int       = 6379
 
   def apply(


### PR DESCRIPTION
各コンテナのデフォルトタグを以下に更新:
- MySQL: 8.0 → 9.4.0
- PostgreSQL: 13-alpine → 15-alpine
- Redis: 6-alpine → 7-alpine
- Memcached: 1.6.18-alpine → 1.6-alpine
- Minio: RELEASE.2023-01-20T02-05-44Z → RELEASE.2024-12-18T13-15-56Z (2回更新)
- LocalStack: 1.4.0 → 3.8.1
- ElasticMQ: 1.4.2 → 1.6.8